### PR TITLE
fix: more permissive geoparquet reading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,9 +173,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "57.3.0"
+version = "58.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4754a624e5ae42081f464514be454b39711daae0458906dacde5f4c632f33a8"
+checksum = "602268ce9f569f282cedb9a9f6bac569b680af47b9b077d515900c03c5d190da"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -184,35 +184,35 @@ dependencies = [
  "arrow-data",
  "arrow-ord",
  "arrow-row",
- "arrow-schema 57.3.0",
+ "arrow-schema",
  "arrow-select",
  "arrow-string",
 ]
 
 [[package]]
 name = "arrow-arith"
-version = "57.3.0"
+version = "58.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
+checksum = "cd53c6bf277dea91f136ae8e3a5d7041b44b5e489e244e637d00ae302051f56f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 57.3.0",
+ "arrow-schema",
  "chrono",
  "num-traits",
 ]
 
 [[package]]
 name = "arrow-array"
-version = "57.3.0"
+version = "58.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
+checksum = "e53796e07a6525edaf7dc28b540d477a934aff14af97967ad1d5550878969b9e"
 dependencies = [
  "ahash 0.8.12",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 57.3.0",
+ "arrow-schema",
  "chrono",
  "chrono-tz",
  "half",
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "57.3.0"
+version = "58.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c697ddca96183182f35b3a18e50b9110b11e916d7b7799cbfd4d34662f2c56c2"
+checksum = "f2c1a85bb2e94ee10b76531d8bc3ce9b7b4c0d508cabfb17d477f63f2617bd20"
 dependencies = [
  "bytes",
  "half",
@@ -236,15 +236,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "57.3.0"
+version = "58.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
+checksum = "89fb245db6b0e234ed8e15b644edb8664673fefe630575e94e62cd9d489a8a26"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-ord",
- "arrow-schema 57.3.0",
+ "arrow-schema",
  "arrow-select",
  "atoi",
  "base64",
@@ -258,12 +258,12 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "57.3.0"
+version = "58.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
+checksum = "189d210bc4244c715fa3ed9e6e22864673cccb73d5da28c2723fb2e527329b33"
 dependencies = [
  "arrow-buffer",
- "arrow-schema 57.3.0",
+ "arrow-schema",
  "half",
  "num-integer",
  "num-traits",
@@ -271,29 +271,29 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "57.3.0"
+version = "58.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf7df950701ab528bf7c0cf7eeadc0445d03ef5d6ffc151eaae6b38a58feff1"
+checksum = "7968c2e5210c41f4909b2ef76f6e05e172b99021c2def5edf3cc48fdd39d1d6c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 57.3.0",
+ "arrow-schema",
  "arrow-select",
  "flatbuffers",
 ]
 
 [[package]]
 name = "arrow-json"
-version = "57.3.0"
+version = "58.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff8357658bedc49792b13e2e862b80df908171275f8e6e075c460da5ee4bf86"
+checksum = "92111dba5bf900f443488e01f00d8c4ddc2f47f5c50039d18120287b580baa22"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
  "arrow-data",
- "arrow-schema 57.3.0",
+ "arrow-schema",
  "chrono",
  "half",
  "indexmap 2.13.0",
@@ -309,69 +309,63 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "57.3.0"
+version = "58.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
+checksum = "211136cb253577ee1a6665f741a13136d4e563f64f5093ffd6fb837af90b9495"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 57.3.0",
+ "arrow-schema",
  "arrow-select",
 ]
 
 [[package]]
 name = "arrow-row"
-version = "57.3.0"
+version = "58.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18228633bad92bff92a95746bbeb16e5fc318e8382b75619dec26db79e4de4c0"
+checksum = "8e0f20145f9f5ea3fe383e2ba7a7487bf19be36aa9dbf5dd6a1f92f657179663"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 57.3.0",
+ "arrow-schema",
  "half",
 ]
 
 [[package]]
 name = "arrow-schema"
-version = "56.2.0"
+version = "58.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
-
-[[package]]
-name = "arrow-schema"
-version = "57.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
+checksum = "1b47e0ca91cc438d2c7879fe95e0bca5329fff28649e30a88c6f760b1faeddcb"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "57.3.0"
+version = "58.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
+checksum = "750a7d1dda177735f5e82a314485b6915c7cccdbb278262ac44090f4aba4a325"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 57.3.0",
+ "arrow-schema",
  "num-traits",
 ]
 
 [[package]]
 name = "arrow-string"
-version = "57.3.0"
+version = "58.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
+checksum = "e1eab1208bc4fe55d768cdc9b9f3d9df5a794cdb3ee2586bf89f9b30dc31ad8c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
- "arrow-schema 57.3.0",
+ "arrow-schema",
  "arrow-select",
  "memchr",
  "num-traits",
@@ -467,9 +461,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -477,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [
  "cc",
  "cmake",
@@ -1134,7 +1128,7 @@ dependencies = [
 [[package]]
 name = "duckdb"
 version = "1.4.4"
-source = "git+https://github.com/duckdb/duckdb-rs?rev=a2639608d946690e04b1d5f6448302d57bb99d7e#a2639608d946690e04b1d5f6448302d57bb99d7e"
+source = "git+https://github.com/gadomski/duckdb-rs?branch=arrow-v58#6e74ebc0f489584f783ead5962b039e75b3f8462"
 dependencies = [
  "arrow",
  "cast",
@@ -1575,14 +1569,13 @@ dependencies = [
 [[package]]
 name = "geoarrow-array"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1cc4106ac0a0a512c398961ce95d8150475c84a84e17c4511c3643fa120a17"
+source = "git+https://github.com/geoarrow/geoarrow-rs?branch=arrow-58#aab41a0727e3e1ab8eb92b0215c05528dcd9d0ce"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
- "arrow-schema 57.3.0",
+ "arrow-schema",
  "geo-traits",
- "geoarrow-schema 0.7.0",
+ "geoarrow-schema",
  "num-traits",
  "wkb",
  "wkt 0.14.0",
@@ -1590,24 +1583,10 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-schema"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f1b18b1c9a44ecd72be02e53d6e63bbccfdc8d1765206226af227327e2be6e"
-dependencies = [
- "arrow-schema 56.2.0",
- "geo-traits",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "geoarrow-schema"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97be4e9f523f92bd6a0e0458323f4b783d073d011664decd8dbf05651704f34"
+source = "git+https://github.com/geoarrow/geoarrow-rs?branch=arrow-58#aab41a0727e3e1ab8eb92b0215c05528dcd9d0ce"
 dependencies = [
- "arrow-schema 57.3.0",
+ "arrow-schema",
  "geo-traits",
  "serde",
  "serde_json",
@@ -1639,18 +1618,17 @@ dependencies = [
 [[package]]
 name = "geoparquet"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "746cda8efa83cd830f85b5b8ee6b60d4ceccbd0a2977e534bfd2313ff4eca615"
+source = "git+https://github.com/geoarrow/geoarrow-rs?branch=arrow-58#aab41a0727e3e1ab8eb92b0215c05528dcd9d0ce"
 dependencies = [
  "arrow-arith",
  "arrow-array",
  "arrow-buffer",
  "arrow-ord",
- "arrow-schema 57.3.0",
+ "arrow-schema",
  "geo-traits",
  "geo-types",
  "geoarrow-array",
- "geoarrow-schema 0.7.0",
+ "geoarrow-schema",
  "indexmap 2.13.0",
  "parquet",
  "serde",
@@ -1695,21 +1673,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -2212,9 +2190,9 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -2258,9 +2236,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819b44bc7c87d9117eb522f14d46e918add69ff12713c475946b0a29363ed1c2"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -2273,9 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470252db18ecc35fd766c0891b1e3ec6cbbcd62507e85276c01bf75d8e94d4a1"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2284,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68971ebff725b9e2ca27a601c5eb38a4c5d64422c4cbab0c535f248087eda5c2"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -2379,9 +2357,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.44.1"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98b64a413c93a1b413dfbaf973b78d271648b9cae50b10302ad88af78991672"
+checksum = "6f29616f6e19415398eb186964fb7cbbeef572c79bede3622a8277667924bbe3"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -2396,7 +2374,7 @@ dependencies = [
  "num-cmp",
  "num-traits",
  "percent-encoding",
- "referencing 0.44.1",
+ "referencing 0.45.0",
  "regex",
  "regex-syntax",
  "reqwest 0.13.2",
@@ -2478,14 +2456,14 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libduckdb-sys"
 version = "1.4.4"
-source = "git+https://github.com/duckdb/duckdb-rs?rev=a2639608d946690e04b1d5f6448302d57bb99d7e#a2639608d946690e04b1d5f6448302d57bb99d7e"
+source = "git+https://github.com/gadomski/duckdb-rs?branch=arrow-v58#6e74ebc0f489584f783ead5962b039e75b3f8462"
 dependencies = [
  "cc",
  "flate2",
@@ -2810,9 +2788,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.5"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
+checksum = "c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb"
 dependencies = [
  "async-trait",
  "base64",
@@ -2833,7 +2811,7 @@ dependencies = [
  "rand 0.9.2",
  "reqwest 0.12.28",
  "ring",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2952,17 +2930,16 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "57.3.0"
+version = "58.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee96b29972a257b855ff2341b37e61af5f12d6af1158b6dcdb5b31ea07bb3cb"
+checksum = "3f491d0ef1b510194426ee67ddc18a9b747ef3c42050c19322a2cd2e1666c29b"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
  "arrow-buffer",
- "arrow-cast",
  "arrow-data",
  "arrow-ipc",
- "arrow-schema 57.3.0",
+ "arrow-schema",
  "arrow-select",
  "base64",
  "brotli",
@@ -3060,7 +3037,7 @@ dependencies = [
 [[package]]
 name = "pgstac"
 version = "0.4.8"
-source = "git+https://github.com/stac-utils/rustac#d50656eb6c90ffdf734a10b1eba053dfc4f49679"
+source = "git+https://github.com/stac-utils/rustac#b25bce2f1297d568da9c5425830beccb645e49f6"
 dependencies = [
  "serde",
  "serde_json",
@@ -3256,9 +3233,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
@@ -3321,15 +3298,15 @@ dependencies = [
 
 [[package]]
 name = "pyo3-arrow"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a08a376a6bbcb28f19122b901ca9ecb9fb7d8d677e886e0e13cd0101d99be4"
+checksum = "0360400036dda3db3d69102ef7e9646e4cd946c75a2d1d41fb8fd39879312636"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
  "arrow-data",
- "arrow-schema 57.3.0",
+ "arrow-schema",
  "arrow-select",
  "chrono",
  "chrono-tz",
@@ -3411,9 +3388,8 @@ dependencies = [
 
 [[package]]
 name = "pyo3-object_store"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a900d022739373b3ea71fc77bbd237e094b478f71e4b5460c4371c9dedf7457"
+version = "0.9.0"
+source = "git+https://github.com/developmentseed/obstore?rev=9a7017a335ba59b062626b478c001c410093a5c7#9a7017a335ba59b062626b478c001c410093a5c7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3474,9 +3450,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -3510,9 +3486,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -3522,6 +3498,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -3688,9 +3670,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.44.1"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22952642836711d7a730d23a4dfb0d732e75a85e4c4f5704266d9c8fac278ff1"
+checksum = "b8a618c14f8ba29d8193bb55e2bf13e4fb2b1115313ecb7ae94b43100c7ac7d5"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -3957,7 +3939,7 @@ dependencies = [
 [[package]]
 name = "rustac"
 version = "0.2.9"
-source = "git+https://github.com/stac-utils/rustac#d50656eb6c90ffdf734a10b1eba053dfc4f49679"
+source = "git+https://github.com/stac-utils/rustac#b25bce2f1297d568da9c5425830beccb645e49f6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3989,7 +3971,7 @@ dependencies = [
  "duckdb",
  "futures-core",
  "futures-util",
- "geoarrow-schema 0.6.2",
+ "geoarrow-schema",
  "geojson",
  "object_store",
  "openssl",
@@ -4068,15 +4050,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4148,9 +4121,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -4407,12 +4380,12 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4477,12 +4450,12 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stac"
 version = "0.16.5"
-source = "git+https://github.com/stac-utils/rustac#d50656eb6c90ffdf734a10b1eba053dfc4f49679"
+source = "git+https://github.com/stac-utils/rustac#b25bce2f1297d568da9c5425830beccb645e49f6"
 dependencies = [
  "arrow-array",
  "arrow-cast",
  "arrow-json",
- "arrow-schema 57.3.0",
+ "arrow-schema",
  "bytes",
  "chrono",
  "cql2",
@@ -4490,7 +4463,7 @@ dependencies = [
  "geo-traits",
  "geo-types",
  "geoarrow-array",
- "geoarrow-schema 0.7.0",
+ "geoarrow-schema",
  "geojson",
  "geoparquet",
  "indexmap 2.13.0",
@@ -4510,7 +4483,7 @@ dependencies = [
 [[package]]
 name = "stac-derive"
 version = "0.3.0"
-source = "git+https://github.com/stac-utils/rustac#d50656eb6c90ffdf734a10b1eba053dfc4f49679"
+source = "git+https://github.com/stac-utils/rustac#b25bce2f1297d568da9c5425830beccb645e49f6"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -4519,17 +4492,17 @@ dependencies = [
 [[package]]
 name = "stac-duckdb"
 version = "0.3.7"
-source = "git+https://github.com/stac-utils/rustac#d50656eb6c90ffdf734a10b1eba053dfc4f49679"
+source = "git+https://github.com/stac-utils/rustac#b25bce2f1297d568da9c5425830beccb645e49f6"
 dependencies = [
  "arrow-array",
- "arrow-schema 57.3.0",
+ "arrow-schema",
  "chrono",
  "cql2",
  "duckdb",
  "geo 0.32.0",
- "geoarrow-schema 0.7.0",
+ "geoarrow-schema",
  "geojson",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "log",
  "serde_json",
  "stac",
@@ -4539,7 +4512,7 @@ dependencies = [
 [[package]]
 name = "stac-io"
 version = "0.2.7"
-source = "git+https://github.com/stac-utils/rustac#d50656eb6c90ffdf734a10b1eba053dfc4f49679"
+source = "git+https://github.com/stac-utils/rustac#b25bce2f1297d568da9c5425830beccb645e49f6"
 dependencies = [
  "async-stream",
  "bytes",
@@ -4560,7 +4533,7 @@ dependencies = [
 [[package]]
 name = "stac-server"
 version = "0.5.1"
-source = "git+https://github.com/stac-utils/rustac#d50656eb6c90ffdf734a10b1eba053dfc4f49679"
+source = "git+https://github.com/stac-utils/rustac#b25bce2f1297d568da9c5425830beccb645e49f6"
 dependencies = [
  "axum",
  "bb8",
@@ -4586,13 +4559,13 @@ dependencies = [
 [[package]]
 name = "stac-validate"
 version = "0.6.7"
-source = "git+https://github.com/stac-utils/rustac#d50656eb6c90ffdf734a10b1eba053dfc4f49679"
+source = "git+https://github.com/stac-utils/rustac#b25bce2f1297d568da9c5425830beccb645e49f6"
 dependencies = [
  "async-recursion",
  "async-trait",
  "fluent-uri 0.4.1",
- "jsonschema 0.44.1",
- "referencing 0.44.1",
+ "jsonschema 0.45.0",
+ "referencing 0.45.0",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
@@ -4907,9 +4880,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4989,7 +4962,7 @@ dependencies = [
  "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -5005,13 +4978,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -5275,9 +5257,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5869,9 +5851,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -6063,18 +6045,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6171,9 +6153,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,22 +14,22 @@ openssl-vendored = ["dep:openssl"]
 
 [dependencies]
 clap = "4.5.59"
-duckdb = { git = "https://github.com/duckdb/duckdb-rs", rev = "a2639608d946690e04b1d5f6448302d57bb99d7e", features = ["serde_json"] }
+duckdb = { git = "https://github.com/gadomski/duckdb-rs", branch = "arrow-v58", features = ["serde_json"] }
 futures-core = "0.3.32"
 futures-util = "0.3.32"
-geoarrow-schema = "0.6.2"
+geoarrow-schema = "0.7.0"
 geojson = "0.24.1"
-object_store = { version = "0.12.4", features = ["gcp", "aws", "azure", "http"] }
+object_store = { version = "0.13.1", features = ["gcp", "aws", "azure", "http"] }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
-parquet = "57.0.0"
+parquet = "58.0.0"
 pyo3 = { version = "0.28.0", features = ["extension-module"] }
-pyo3-arrow = "0.16.0"
+pyo3-arrow = "0.17.0"
 pyo3-async-runtimes = { version = "0.28.0", features = [
     "tokio",
     "tokio-runtime",
 ] }
 pyo3-log = "0.13.0"
-pyo3-object_store = "0.10.0"
+pyo3-object_store = { git = "https://github.com/developmentseed/obstore", rev = "9a7017a335ba59b062626b478c001c410093a5c7" }
 pythonize = "0.28.0"
 rustac = { git = "https://github.com/stac-utils/rustac", features = ["pgstac"] }
 serde = "1.0.217"
@@ -43,3 +43,8 @@ tracing = "0.1.44"
 
 [build-dependencies]
 cargo-lock = "11"
+
+[patch.crates-io]
+geoparquet = { git = "https://github.com/geoarrow/geoarrow-rs", branch = "arrow-58" }
+geoarrow-array = { git = "https://github.com/geoarrow/geoarrow-rs", branch = "arrow-58" }
+geoarrow-schema = { git = "https://github.com/geoarrow/geoarrow-rs", branch = "arrow-58" }

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -11,3 +11,11 @@ def test_to_arrow(item: dict[str, Any]) -> None:
     table = rustac.to_arrow([item])
     data_frame = GeoDataFrame.from_arrow(table)
     assert len(data_frame) == 1
+
+
+def test_from_arrow(item: dict[str, Any]) -> None:
+    from arro3.core import Table
+
+    data_frame = GeoDataFrame.from_features([item])
+    item_collection = rustac.from_arrow(Table.from_arrow(data_frame.to_arrow()))
+    assert len(item_collection["features"]) == 1


### PR DESCRIPTION
Requires a lot of patches to arrow v58 in upstreams. Closes #251